### PR TITLE
refactor: improve report typing

### DIFF
--- a/src/utils/reportGenerator.ts
+++ b/src/utils/reportGenerator.ts
@@ -1,7 +1,58 @@
 // Utility functions for generating and downloading reports
 
-export const generatePaymentsReport = (payments: any[]) => {
-  const reportData = {
+export interface Payment {
+  status: 'Pagado' | 'Pendiente' | 'Vencido';
+  [key: string]: unknown;
+}
+
+export interface UserRecord {
+  status: string;
+  balance: string;
+  [key: string]: unknown;
+}
+
+export interface Reservation {
+  status: 'Aprobada' | 'Pendiente' | 'Completada' | 'Rechazada';
+  [key: string]: unknown;
+}
+
+interface PaymentsReport {
+  title: string;
+  generatedAt: string;
+  summary: {
+    totalPayments: number;
+    totalPaid: number;
+    totalPending: number;
+    totalOverdue: number;
+  };
+  payments: Payment[];
+}
+
+interface UsersReport {
+  title: string;
+  generatedAt: string;
+  summary: {
+    totalUsers: number;
+    activeUsers: number;
+    usersWithDebt: number;
+  };
+  users: UserRecord[];
+}
+
+interface ReservationsReport {
+  title: string;
+  generatedAt: string;
+  summary: {
+    totalReservations: number;
+    approved: number;
+    pending: number;
+    completed: number;
+  };
+  reservations: Reservation[];
+}
+
+export const generatePaymentsReport = (payments: Payment[]): PaymentsReport => {
+  const reportData: PaymentsReport = {
     title: 'Reporte de Pagos - Torres del Valle',
     generatedAt: new Date().toLocaleDateString('es-ES'),
     summary: {
@@ -10,14 +61,14 @@ export const generatePaymentsReport = (payments: any[]) => {
       totalPending: payments.filter(p => p.status === 'Pendiente').length,
       totalOverdue: payments.filter(p => p.status === 'Vencido').length,
     },
-    payments: payments
+    payments,
   };
 
   return reportData;
 };
 
-export const generateUsersReport = (users: any[]) => {
-  const reportData = {
+export const generateUsersReport = (users: UserRecord[]): UsersReport => {
+  const reportData: UsersReport = {
     title: 'Reporte de Usuarios - Torres del Valle',
     generatedAt: new Date().toLocaleDateString('es-ES'),
     summary: {
@@ -25,14 +76,14 @@ export const generateUsersReport = (users: any[]) => {
       activeUsers: users.filter(u => u.status === 'Activo').length,
       usersWithDebt: users.filter(u => u.balance !== '$0').length,
     },
-    users: users
+    users,
   };
 
   return reportData;
 };
 
-export const generateReservationsReport = (reservations: any[]) => {
-  const reportData = {
+export const generateReservationsReport = (reservations: Reservation[]): ReservationsReport => {
+  const reportData: ReservationsReport = {
     title: 'Reporte de Reservas - Torres del Valle',
     generatedAt: new Date().toLocaleDateString('es-ES'),
     summary: {
@@ -41,63 +92,72 @@ export const generateReservationsReport = (reservations: any[]) => {
       pending: reservations.filter(r => r.status === 'Pendiente').length,
       completed: reservations.filter(r => r.status === 'Completada').length,
     },
-    reservations: reservations
+    reservations,
   };
 
   return reportData;
 };
 
-export const downloadCSV = (data: any[], filename: string) => {
+export const downloadCSV = (data: Record<string, unknown>[], filename: string): void => {
   if (!data.length) return;
 
   const headers = Object.keys(data[0]).join(',');
-  const rows = data.map(item => 
-    Object.values(item).map(value => 
-      typeof value === 'string' && value.includes(',') 
-        ? `"${value}"` 
-        : value
-    ).join(',')
+  const rows = data.map(item =>
+    Object.values(item)
+      .map(value =>
+        typeof value === 'string' && value.includes(',')
+          ? `"${value}"`
+          : String(value)
+      )
+      .join(',')
   );
 
   const csvContent = [headers, ...rows].join('\n');
-  
+
   const blob = new Blob([csvContent], { type: 'text/csv' });
   const url = window.URL.createObjectURL(blob);
-  
+
   const link = document.createElement('a');
   link.href = url;
   link.download = `${filename}.csv`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  
+
   window.URL.revokeObjectURL(url);
 };
 
-export const downloadPDF = (reportData: any) => {
+interface ReportData {
+  title: string;
+  generatedAt: string;
+  summary: Record<string, number>;
+  [key: string]: unknown;
+}
+
+export const downloadPDF = (reportData: ReportData): void => {
   // Simplified PDF generation - in a real app you'd use a library like jsPDF
   const content = `
     ${reportData.title}
     Generado el: ${reportData.generatedAt}
-    
+
     RESUMEN:
     ${Object.entries(reportData.summary)
       .map(([key, value]) => `${key}: ${value}`)
       .join('\n')}
-    
+
     DATOS:
     ${JSON.stringify(reportData, null, 2)}
   `;
 
   const blob = new Blob([content], { type: 'text/plain' });
   const url = window.URL.createObjectURL(blob);
-  
+
   const link = document.createElement('a');
   link.href = url;
   link.download = `${reportData.title.replace(/\s+/g, '_')}.txt`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  
+
   window.URL.revokeObjectURL(url);
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -129,5 +130,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- fix Tailwind config to use ESM plugin import
- add strict TypeScript types for report generation and downloads

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a39f4fb948324b84be92e3a50ae97