### PR TITLE
Escape quotes in CSV export

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --experimental-strip-types tests/downloadCSV.test.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/utils/reportGenerator.ts
+++ b/src/utils/reportGenerator.ts
@@ -51,12 +51,16 @@ export const downloadCSV = (data: any[], filename: string) => {
   if (!data.length) return;
 
   const headers = Object.keys(data[0]).join(',');
-  const rows = data.map(item => 
-    Object.values(item).map(value => 
-      typeof value === 'string' && value.includes(',') 
-        ? `"${value}"` 
-        : value
-    ).join(',')
+  const rows = data.map(item =>
+    Object.values(item)
+      .map(value => {
+        if (typeof value === 'string') {
+          const sanitized = value.replace(/"/g, '""');
+          return /[",\n]/.test(value) ? `"${sanitized}"` : sanitized;
+        }
+        return value;
+      })
+      .join(',')
   );
 
   const csvContent = [headers, ...rows].join('\n');

--- a/tests/downloadCSV.test.ts
+++ b/tests/downloadCSV.test.ts
@@ -1,0 +1,33 @@
+import { downloadCSV } from '../src/utils/reportGenerator.ts';
+import { strict as assert } from 'assert';
+
+// Minimal DOM stubs
+(global as any).window = {
+  URL: {
+    createObjectURL: () => 'blob:url',
+    revokeObjectURL: () => {}
+  }
+};
+(global as any).document = {
+  body: {
+    appendChild: () => {},
+    removeChild: () => {}
+  },
+  createElement: () => ({ href: '', download: '', click: () => {} })
+};
+
+// Capture the CSV content written to the Blob
+let captured = '';
+const OriginalBlob = Blob;
+(global as any).Blob = class extends OriginalBlob {
+  constructor(parts: any[], opts?: any) {
+    captured = parts.join('');
+    super(parts, opts);
+  }
+};
+
+const data = [{ name: 'John "Doe"', note: 'Said "Hello"' }];
+downloadCSV(data, 'test');
+
+assert.equal(captured, 'name,note\n"John ""Doe""","Said ""Hello"""');
+console.log('downloadCSV handles quotes correctly');


### PR DESCRIPTION
## Summary
- Escape double quotes when building CSV values to support data containing quotes
- Add manual test validating that `downloadCSV` handles values with quotes
- Add npm test script using Node's `--experimental-strip-types`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in many files)*

------
https://chatgpt.com/codex/tasks/task_e_689a4fc805988324b362c8968e4243fa