### PR TITLE
Rename report download to plain text

### DIFF
--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { DollarSign, Plus, Filter, Download, TrendingUp, Building } from 'lucide-react';
 import { NewChargeDialog } from '@/components/dialogs/NewChargeDialog';
 import { PaymentDetailsDialog } from '@/components/dialogs/PaymentDetailsDialog';
-import { generatePaymentsReport, downloadCSV, downloadPDF } from '@/utils/reportGenerator';
+import { generatePaymentsReport, downloadCSV, downloadReportText } from '@/utils/reportGenerator';
 import { useToast } from '@/hooks/use-toast';
 
 export default function PaymentsPage() {
@@ -74,7 +74,7 @@ export default function PaymentsPage() {
 
   const handleExportReport = () => {
     const report = generatePaymentsReport(payments);
-    downloadPDF(report);
+    downloadReportText(report);
     toast({
       title: "Reporte generado",
       description: "El reporte de pagos se ha descargado exitosamente",

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -6,7 +6,7 @@ import { Calendar, Clock, Plus, Filter, MapPin } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { NewReservationDialog } from '@/components/dialogs/NewReservationDialog';
 import { ReservationDetailsDialog } from '@/components/dialogs/ReservationDetailsDialog';
-import { generateReservationsReport, downloadPDF } from '@/utils/reportGenerator';
+import { generateReservationsReport, downloadReportText } from '@/utils/reportGenerator';
 import { useToast } from '@/hooks/use-toast';
 
 export default function Reservations() {
@@ -82,7 +82,7 @@ export default function Reservations() {
 
   const handleGenerateReport = () => {
     const report = generateReservationsReport(reservations);
-    downloadPDF(report);
+    downloadReportText(report);
     toast({
       title: "Reporte generado",
       description: "El reporte de reservas se ha descargado exitosamente",

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Users, Plus, Search, Filter, Building, Mail, Phone } from 'lucide-react';
 import { NewUserDialog } from '@/components/dialogs/NewUserDialog';
-import { generateUsersReport, downloadPDF } from '@/utils/reportGenerator';
+import { generateUsersReport, downloadReportText } from '@/utils/reportGenerator';
 import { useToast } from '@/hooks/use-toast';
 
 export default function UsersPage() {
@@ -68,7 +68,7 @@ export default function UsersPage() {
 
   const handleGenerateReport = () => {
     const report = generateUsersReport(users);
-    downloadPDF(report);
+    downloadReportText(report);
     toast({
       title: "Reporte generado",
       description: "El reporte de usuarios se ha descargado exitosamente",

--- a/src/utils/reportGenerator.ts
+++ b/src/utils/reportGenerator.ts
@@ -74,30 +74,30 @@ export const downloadCSV = (data: any[], filename: string) => {
   window.URL.revokeObjectURL(url);
 };
 
-export const downloadPDF = (reportData: any) => {
-  // Simplified PDF generation - in a real app you'd use a library like jsPDF
+export const downloadReportText = (reportData: any) => {
+  // Download the report data as a plain text file
   const content = `
-    ${reportData.title}
-    Generado el: ${reportData.generatedAt}
-    
-    RESUMEN:
-    ${Object.entries(reportData.summary)
-      .map(([key, value]) => `${key}: ${value}`)
-      .join('\n')}
-    
-    DATOS:
-    ${JSON.stringify(reportData, null, 2)}
-  `;
+${reportData.title}
+Generado el: ${reportData.generatedAt}
+
+RESUMEN:
+${Object.entries(reportData.summary)
+  .map(([key, value]) => `${key}: ${value}`)
+  .join('\n')}
+
+DATOS:
+${JSON.stringify(reportData, null, 2)}
+`;
 
   const blob = new Blob([content], { type: 'text/plain' });
   const url = window.URL.createObjectURL(blob);
-  
+
   const link = document.createElement('a');
   link.href = url;
   link.download = `${reportData.title.replace(/\s+/g, '_')}.txt`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  
+
   window.URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
## Summary
- rename downloadPDF to downloadReportText and adjust blob content and filename
- update report pages to call downloadReportText

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any types)

------
https://chatgpt.com/codex/tasks/task_e_689a4fcc25608324aa666f4b73a3d44d