### PR TITLE
Add payment report generator test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -78,6 +79,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/utils/__tests__/reportGenerator.test.ts
+++ b/src/utils/__tests__/reportGenerator.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { generatePaymentsReport } from '../reportGenerator';
+
+describe('generatePaymentsReport', () => {
+  it('retorna estadísticas de pagos correctas', () => {
+    const payments = [
+      { status: 'Pagado' },
+      { status: 'Pagado' },
+      { status: 'Pendiente' },
+      { status: 'Vencido' },
+    ];
+
+    const report = generatePaymentsReport(payments);
+
+    expect(report.summary.totalPaid).toBe(2);
+    expect(report.summary.totalPending).toBe(1);
+    expect(report.summary.totalOverdue).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest script and dependency
- create test ensuring payment report counts paid, pending, and overdue totals

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a4fcf13348324b261cf2325fe2a88